### PR TITLE
Update HomeMarketCards

### DIFF
--- a/src/components/home-market-cards/HomeMarketCards.jsx
+++ b/src/components/home-market-cards/HomeMarketCards.jsx
@@ -48,7 +48,7 @@ const HomeMarketCards = () => {
 
   return (
     <Slider {...settings}>
-      {forex.length > 5
+      {forex.length > 4
         ? forex.map((data, index) => (
             <div key={index}>
               <MarketCards


### PR DESCRIPTION
The rationale of this change is to update `HomeMarketCards` to start rendering charts when there are at least 4 of them present. Due to (most likely because of the financialModelingPrep API changes again) a bug in production and some of the charts returning empty array (always happened at the way 1 chart is not present), I needed to update this.